### PR TITLE
[BCTW-227] Updating Fields in Create Operator Interface

### DIFF
--- a/frontend/src/assets/styl/base.styl
+++ b/frontend/src/assets/styl/base.styl
@@ -89,6 +89,13 @@ th, td
   padding 0.75rem
   font-size 1rem
 
+// Multiselect doesn't support icon pack changes so we fix it!
+.vs-select--item.con-icon.activex .vs-select--item-icon
+  display none
+
+.vs-select-primary .vs-select--item.activex
+  padding 1rem
+
 .vs-con-table table
   font-size 1rem
 
@@ -100,3 +107,8 @@ th, td
 
 .con-vs-chip .vs-chip--text
   font-size 0.9375rem
+
+// Input Hints
+.con-text-validation .span-text-validation
+  padding 0.5rem 0
+  font-size 0.875rem

--- a/frontend/src/views/CreateOperator.vue
+++ b/frontend/src/views/CreateOperator.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="content-wrapper">
+    
+    <!-- BREADCRUMB LANDMARK -->
     <nav class="breadcrumbs" aria-label="breadcrumbs">
       <router-link to="/">
         <vs-icon 
@@ -10,22 +12,26 @@
       </router-link>
     </nav>
 
+    <!-- MAIN LANDMARK -->
     <main>
       <h1>Create Operator</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       
       <div class="stepper">
 
+        <!-- OPERATOR DETAILS -->
         <section ref="detailSection"
           class="stepper-section"
         >
-          <header @click="openStep1()">
+          <header @click="gotoSection1()">
             <h2>Operator Detail</h2>
           </header>
 
+          <!-- TODO: Operator Detail Form needs to be built as a component for reuse in edit views -->
           <form
             class="operator-details-form"
             v-show="this.step1Active"
+            :aria-hidden="!this.step1Active"
           >
 
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -39,6 +45,7 @@
                 <vs-input
                   label="Operator Name"
                   size="large"
+                  color="primary"
                   v-model="operatorName"
                 />
               </vs-col>
@@ -151,6 +158,7 @@
                   color="primary"
                   size="large"
                   type="filled"
+                  class="font-weight-bold"
                   @click="gotoSection2('tenureSection')"
                 >
                   Continue
@@ -169,17 +177,19 @@
 
         </section>
 
-        <!-- Tenure Section -->
+        <!-- TENURES -->
         <section ref="tenureSection"
           class="stepper-section"
         >
-          <header @click="openStep2()">
-            <h2>Add Tenures</h2>
+          <header @click="gotoSection2()">
+            <h2>Active Tenures</h2>
           </header>
           
+          <!-- TODO: Operator Detail Form needs to be built as a component for reuse in edit views -->
           <form
             ref="tenure"
-            :class="{collapsed : !this.step2Active}"
+            v-show="this.step2Active"
+            :aria-hidden="!this.step2Active"
           >
 
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -211,19 +221,6 @@
                     vs-justify="center" 
                     vs-align="center" 
                     vs-w="12">
-                    <vs-input
-                      label="File Number"
-                      size="large"
-                      v-model="tenure.tenureFileNumber"
-                    />
-                  </vs-col>
-                </vs-row>
-                <vs-row>
-                  <vs-col 
-                    vs-type="flex"
-                    vs-justify="center" 
-                    vs-align="center" 
-                    vs-w="12">
                     <vs-select
                       label="Tenure Type"
                       placeholder="Select a Type"
@@ -233,11 +230,40 @@
                       <vs-select-item 
                         :key="index"
                         :value="item.value" 
-                        :text="item.type" 
+                        :text="item.text" 
                         v-for="(item, index) in tenureTypes"
-
                       />
                     </vs-select>
+                  </vs-col>
+                </vs-row>
+                <vs-row>
+                  <vs-col 
+                    vs-type="flex"
+                    vs-justify="center" 
+                    vs-align="center" 
+                    vs-w="12">
+                    <vs-input
+                      label="Application File Number"
+                      description-text="Example: 1234567890"
+                      size="large"
+                      type="number"
+                      v-model="tenure.applicationFileNumber"
+                    />
+                  </vs-col>
+                </vs-row>
+                <vs-row>
+                  <vs-col 
+                    vs-type="flex"
+                    vs-justify="center" 
+                    vs-align="center" 
+                    vs-w="12">
+                    <vs-input
+                      label="Document Number"
+                      description-text="Example: 1234567890"
+                      size="large"
+                      type="number"
+                      v-model="tenure.tenureDocumentNumber"
+                    />
                   </vs-col>
                 </vs-row>
                 <vs-row>
@@ -245,11 +271,11 @@
                     vs-w="12">
 
                     <vs-select
-                      autocomplete
-                      label="Tenure Regions"
+                      multiple
+                      label="Regions"
                       placeholder="Select a Region"
                       class="large"
-                      v-model="tenure.tenureRegionOptions"
+                      v-model="tenure.tenureRegions"
                     >
                       <vs-select-item
                         :key="index"
@@ -258,22 +284,6 @@
                         v-for="(item, index) in regionOptions" />
                     </vs-select>
 
-                    <!-- <label class="vs-input--label">Tenure Regions</label>
-                    <vs-chips
-                      class="custom-chips"
-                      placeholder="New Element"
-                      v-model="tenureRegions">
-                      <vs-chip
-                        closable
-                        icon-pack="mdi"
-                        close-icon="mdi-close"
-                        :key="region"
-                        @click="remove(chip)"
-                        v-for="region in tenureRegions">
-                        {{ region }}
-                      </vs-chip>
-                    </vs-chips> -->
-
                   </vs-col>
                 </vs-row>
                 <vs-row>
@@ -281,34 +291,42 @@
                     vs-w="12">
 
                     <vs-select
-                      autocomplete
+                      multiple
                       label="Activities"
+                      placeholder="Select Activities"
                       class="large"
-                      v-model="tenure.activities"
+                      v-model="tenure.tenureActivities"
                     >
-                      <vs-select-item
-                        :key="index"
-                        :value="item.value"
-                        :text="item.text"
-                        v-for="(item, index) in activityOptions" />
+                    <vs-select-item
+                      icon-pack="mdi"
+                      icon="mdi-plus"
+                      :key="index"
+                      :value="item.value"
+                      :text="item.text"
+                      v-for="(item, index) in activityOptions" />
                     </vs-select>
 
-                    <!-- <label class="vs-input--label">Tenure Regions</label>
-                    <vs-chips
-                      class="custom-chips"
-                      placeholder="New Element"
-                      v-model="tenureRegions">
-                      <vs-chip
-                        closable
-                        icon-pack="mdi"
-                        close-icon="mdi-close"
-                        :key="region"
-                        @click="remove(chip)"
-                        v-for="region in tenureRegions">
-                        {{ region }}
-                      </vs-chip>
-                    </vs-chips> -->
-
+                  </vs-col>
+                </vs-row>
+                 <vs-row>
+                  <vs-col 
+                    vs-type="flex"
+                    vs-justify="center" 
+                    vs-align="center" 
+                    vs-w="12">
+                    <vs-select
+                      label="Responsible Business Unit"
+                      placeholder="Select a Business Unit"
+                      class="large"
+                      v-model="tenure.businessUnit"
+                      >
+                      <vs-select-item 
+                        :key="index"
+                        :value="item.value" 
+                        :text="item.text" 
+                        v-for="(item, index) in businessUnitOptions"
+                      />
+                    </vs-select>
                   </vs-col>
                 </vs-row>
               </fieldset>
@@ -328,7 +346,7 @@
                   icon="mdi-plus"
                 >
                 </vs-icon>
-                Add Another Tenure
+                Add Tenure
               </vs-button>
             </div>
 
@@ -352,6 +370,7 @@
                     color="primary"
                     size="large"
                     type="filled"
+                    class="font-weight-bold"
                     @click="gotoSection3('permitSection')"
                   >
                     Continue
@@ -371,18 +390,22 @@
         
         </section>
 
-        <!-- Permit Section -->
+        <!-- PERMITS -->
         <section ref="permitSection"
           class="stepper-section"
         >
-          <header @click="openStep3()">
-            <h2>Add BC Parks Permits</h2>
+          <header @click="gotoSection3()">
+            <h2>BC Parks Permits</h2>
           </header>
 
-            <form :class="{collapsed : !this.step3Active}">
-
+            <!-- TODO: Permit Form needs to be built as a component for reuse in edit views -->
+            <form
+              v-show="this.step3Active"
+              :aria-hidden="!this.step3Active"
+            >
+              
               <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-
+              
               <vs-row
                 v-for="(permit, index) in permits" 
                 :key="index"
@@ -391,9 +414,8 @@
                   <fieldset class="group-fieldset">
                     <legend>Permit <span>{{permit.index}}</span></legend>
                     <vs-button
-                      size="large"
                       type="flat"
-                      class="remove-group-btn"
+                      class="remove-group-btn font-weight-bold"
                       @click="$delete(permits, index)"
                     >
                       <vs-icon
@@ -411,6 +433,7 @@
                         vs-w="12">
                         <vs-input
                           label="Permit Number"
+                          description-text="Example: 1234567890"
                           size="large"
                           v-model="permit.permitNumber"
                         />
@@ -424,6 +447,7 @@
                         vs-w="12">
                         <vs-input
                           label="Application File Number"
+                          description-text="Example: 1234567890"
                           size="large"
                           v-model="permit.applicationFileNumber"
                         />
@@ -436,8 +460,9 @@
                         vs-align="center" 
                         vs-w="12">
                         <vs-select
-                          autocomplete
+                          multiple
                           label="Protected Lands"
+                          placeholder="Select"
                           class="large"
                           v-model="permit.protectedLands"
                         >
@@ -466,7 +491,7 @@
                     icon="mdi-plus"
                   >
                   </vs-icon>
-                  Add Another Permit
+                  Add Permit
                 </vs-button>
               </div>
 
@@ -490,6 +515,7 @@
                       color="primary"
                       size="large"
                       type="filled"
+                      class="font-weight-bold"
                       @click="gotoSection3('permitSection')"
                     >
                       Create Operator
@@ -517,10 +543,13 @@ export default {
   name: 'CreateOperator',
 
   data:()=>({
+
+    // Wizard States
     step1Active: true,
     step2Active: false,
     step3Active: false,
 
+    // Operator Details
     operatorName: '',
     emailAddress: '',
     phoneNumber: '',
@@ -528,93 +557,74 @@ export default {
     mailStreet: '',
     mailCity: '',
     mailRegion: '',
-    mailRegions: [
-      {text:'Alberta', value:0},
-      {text:'British Columbia', value:1},
-    ],
-
-    activityOptions: [
-      {text: 'Activity 1', value:1},
-      {text: 'Activity 2', value:0}
-    ],
-
-    protectedLandsOptions: [
-      {text:'Protected Land 1', value:1},
-      {text:'Protected Land 2', value:2},
-      {text:'Protected Land 3', value:3},
-    ],
-
-    regionOptions:[
-      {text:'Tenure Region 1', value:1},
-      {text:'Tenure Region 2', value:2},
-      {text:'Tenure Region 3', value:3},
-    ],
-
-    tenureTypes: [
-      {type: 'type 1'},
-      {type: 'type 2'}
-    ],
-
+    
+    // Operator Permits
     permits: [
       {
         permitNumber: '',
         applicationFileNumber: '',
         protectedLands: [
-          {
-            text: '',
-            value: ''
-          }
         ]
       }
     ],
 
+    // Operator Tenures
     tenures: [
       {
-        tenurefileNumber: '',
+        applicationfileNumber: '',
         tenureActivities: [
         ],
+        tenureDocumentNumber: '',
         tenureRegions: [
         ],
         tenureType: '',
+        businessUnit: ''
       }
     ],
+
+    // Prepopulated Options
+
+    // Activities
+    activityOptions: [
+      {text: 'Activity 1', value: 1},
+      {text: 'Activity 2', value: 2}
+    ],
+
+    // Business Units
+    businessUnitOptions: [
+      {text: 'Business Unit 1', value: 1},
+      {text: 'Business Unit 2', value: 2}
+    ],
+
+    // Mailing Address Regions
+    mailRegions: [
+      {text:'Alberta', value:0},
+      {text:'British Columbia', value: 1},
+    ],
+
+
+    // Protected Lands
+    protectedLandsOptions: [
+      {text:'Protected Land 1', value: 1},
+      {text:'Protected Land 2', value: 2},
+      {text:'Protected Land 3', value: 3},
+    ],
+
+    // Regions
+    regionOptions:[
+      {text:'Tenure Region 1', value: 1},
+      {text:'Tenure Region 2', value: 2},
+      {text:'Tenure Region 3', value: 3},
+    ],
+
+    // Tenure Types
+    tenureTypes: [
+      {text: 'Lease', value: 1},
+      {text: 'License of Occupation', value: 2}
+    ]
   }),
 
   methods: {
-    openStep1: function () {
-      this.step1Active = true
-      this.step2Active = false
-      this.step3Active = false
-      window.scrollTo({top: 0, behavior: 'smooth'});
-    },
-
-    openStep2: function () {
-      this.step2Active = true
-      this.step1Active = false
-      this.step3Active = false
-      window.scrollTo({top: 0, behavior: 'smooth'});
-    }, 
-
-    openStep3: function () {
-      this.step1Active = false
-      this.step2Active = false
-      this.step3Active = true
-    }, 
-
-    addNewTenure: function () {
-      this.tenures.push({
-        fileNumber: '',
-        tenureType: ''
-      })
-    },
-
-    addNewPermit: function () {
-      this.permits.push({
-        permitNumber: '',
-        applicationFileNumber: ''
-      })
-    },
-
     // Prototype w/ Scrolling Functionality
     gotoSection1: function () {
       this.$smoothScroll({
@@ -631,7 +641,7 @@ export default {
       this.$smoothScroll({
         scrollTo: this.$refs.tenureSection,
         duration: 1000,
-        offset: -100,
+        offset: -1000,
       })
       this.step1Active = false
       this.step2Active = true
@@ -647,7 +657,43 @@ export default {
       this.step1Active = false
       this.step2Active = false
       this.step3Active = true
-    }
+    },
+
+    // Add additional Tenure to Operator
+    addNewTenure: function () {
+      this.tenures.push({
+        applicationFileNumber: '',
+        businessUnit: '',
+        tenureActivities: [
+          {
+            text: '',
+            value: ''
+          }
+        ],
+        tenureDocumentNumber: '',
+        tenureRegions: [
+          {
+            text: '',
+            value: ''
+          }
+        ],
+        tenureType: ''
+      })
+    },
+
+    // Add additional Permit to Operator
+    addNewPermit: function () {
+      this.permits.push({
+        permitNumber: '',
+        applicationFileNumber: '',
+        protectedLands: [
+          {
+            text: '',
+            value: ''
+          }
+        ]
+      })
+    },
   }
 }
 </script>

--- a/frontend/src/views/index.vue
+++ b/frontend/src/views/index.vue
@@ -9,7 +9,7 @@
       <section
         class="stepper-section"
       >
-        <header @click="openStep1()">
+        <header @click="gotoStep1()">
           <h2>Operator Detail</h2>
         </header>
 


### PR DESCRIPTION
Updating / adding missing fields from acceptance criteria for the following components of the Create Operator interface.

**Tenures**
* Added new fields (Document Number, Responsible Business Unit)
* Added multi-select option for Regions and Activities
* Added placeholder hints for various fields (content TBD)

**Permits**
* Added multi-select option for Protected Lands
* Added placeholder hints for various fields (content TBD)

**Additional Fixes**
* Fixed issue with select component not showing correct iconography
* Increased legibility of input help text
* Commented sections of Create Operator markup
* Removed unused functions from section headers